### PR TITLE
[TA-2047] POA-01: Move File `genesis.go` Used to Init/Export Genesis State to Keeper

### DIFF
--- a/x/poa/keeper/genesis.go
+++ b/x/poa/keeper/genesis.go
@@ -1,19 +1,18 @@
-package poa
+package keeper
 
 import (
-	"github.com/Peersyst/exrp/x/poa/keeper"
 	"github.com/Peersyst/exrp/x/poa/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // InitGenesis initializes the module's state from a provided genesis state.
-func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 	// this line is used by starport scaffolding # genesis/module/init
 	k.SetParams(ctx, genState.Params)
 }
 
 // ExportGenesis returns the module's exported genesis
-func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
+func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
 

--- a/x/poa/module.go
+++ b/x/poa/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	// this line is used by starport scaffolding # 1
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -134,14 +135,14 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 	// Initialize global index to index in genesis state
 	cdc.MustUnmarshalJSON(gs, &genState)
 
-	InitGenesis(ctx, am.keeper, genState)
+	am.keeper.InitGenesis(ctx, genState)
 
 	return []abci.ValidatorUpdate{}
 }
 
 // ExportGenesis returns the module's exported genesis state as raw JSON bytes.
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
-	genState := ExportGenesis(ctx, am.keeper)
+	genState := am.keeper.ExportGenesis(ctx)
 	return cdc.MustMarshalJSON(genState)
 }
 


### PR DESCRIPTION
# POA-01: Move File `genesis.go` Used to Init/Export Genesis State to Keeper PR

## Issues :1st_place_medal: 
- [POA-01 | File `genesis.go` Used to Init/Export Genesis State Is Not Located in Keeper](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=341df8f7519f4f0d93818a40aeb7858d&pm=s) ([Audit link](https://skyharbor.certik.com/shared-report/4130da9b-fd86-421f-8b64-0d1bdc6bd1d8?findingIndex=POA-01))

## Changes :hammer_and_wrench: 
- Move  `genesis.go` to keeper poa pkg and keeper funcs
- Update app usage of genesis functions