### PR TITLE
[TA-2048] EVE-01: Fix Duplicated Event Attribute Names

### DIFF
--- a/x/poa/types/events.go
+++ b/x/poa/types/events.go
@@ -7,5 +7,5 @@ const (
 	AttributeValidator     = "address"
 	AttributeHeight        = "height"
 	AttributeStakingTokens = "staking_tokens"
-	AttributeBankTokens    = "staking_tokens"
+	AttributeBankTokens    = "bank_tokens"
 )


### PR DESCRIPTION
# EVE-01: Fix Duplicated Event Attribute Names PR

## Issues :1st_place_medal: 
- [EVE-01 | Duplicated Event Attribute Names](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=dadd92b8b8a04e879f8999f5249d9a75&pm=s) ([Audit link](https://skyharbor.certik.com/shared-report/4130da9b-fd86-421f-8b64-0d1bdc6bd1d8?findingIndex=EVE-01))

## Changes :hammer_and_wrench: 
- Rename event attribute `AttributeBankTokens` to make more sense