### PR TITLE
[TA-2049] KEK-02: Add Missing Validation of Authority Account in `NewKeeper()`

### DIFF
--- a/x/poa/keeper/keeper.go
+++ b/x/poa/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -35,6 +36,11 @@ func NewKeeper(
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
 		ps = ps.WithKeyTable(types.ParamKeyTable())
+	}
+
+	_, err := sdk.AccAddressFromBech32(authority)
+	if err != nil {
+		panic(err)
 	}
 
 	return &Keeper{


### PR DESCRIPTION
# KEK-02: Add Missing Validation of Authority Account in `NewKeeper()` PR

## Issues :1st_place_medal: 
- [KEK-02 | Missing Validation of Authority Account in `NewKeeper()`](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=71a3e53803934aac9d2a3618ccc8c699&pm=s) ([Audit link](https://skyharbor.certik.com/shared-report/4130da9b-fd86-421f-8b64-0d1bdc6bd1d8?findingIndex=KEK-02))

## Changes :hammer_and_wrench: 
- Add check authority is valid bech32 address in `NewKeeper()`