### PR TITLE
[TA-2050] TXC-01: Add Proposal Informationin Proposals to Add and Remove Validator

### DIFF
--- a/x/poa/client/cli/tx.go
+++ b/x/poa/client/cli/tx.go
@@ -2,11 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/Peersyst/exrp/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -51,7 +52,7 @@ $ %s tx gov submit-proposal add-validator <address> --from=<key_or_address>
 				return err
 			}
 			address := args[0]
-			content := types.NewAddValidatorProposal("title", "description", address)
+			content := types.NewAddValidatorProposal("add validator", "proposal to add a new validator in the chain", address)
 			fmt.Println(address)
 			fmt.Printf("%+v\n", content)
 			from := clientCtx.GetFromAddress()
@@ -103,7 +104,7 @@ $ %s tx gov submit-proposal remove-validator <address> --from=<key_or_address>
 				return err
 			}
 			address := args[0]
-			content := types.NewRemoveValidatorProposal("title", "description", address)
+			content := types.NewRemoveValidatorProposal("remove validator", "proposal to remove an existent validator", address)
 
 			from := clientCtx.GetFromAddress()
 


### PR DESCRIPTION
# TXC-01: Add Proposal Informationin Proposals to Add and Remove Validator PR

## Issues :1st_place_medal: 
- [TXC-01 | Default Proposal Information Is Used in Proposals to Add and Remove Validator](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=b951ce7531f4469fbbe2f903ebe6d20a&pm=s) ([Audit link](https://skyharbor.certik.com/shared-report/4130da9b-fd86-421f-8b64-0d1bdc6bd1d8?findingIndex=TXC-01))

## Changes :hammer_and_wrench: 
- Add title and description for Add and Remove Validator Proposals