### PR TITLE
[TA-2051] TXC-02: Fix Inaccurate Examples in `NewSubmitAddValidatorProposalTxCmd` and `NewSubmitRemoveValidatorProposalTxCmd`

### DIFF
--- a/x/poa/client/cli/tx.go
+++ b/x/poa/client/cli/tx.go
@@ -2,11 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/Peersyst/exrp/x/poa/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,7 +41,7 @@ func NewSubmitAddValidatorProposalTxCmd() *cobra.Command {
 			fmt.Sprintf(`Submit an AddValidator proposal
 
 Example:
-$ %s tx gov submit-proposal add-validator <address> --from=<key_or_address>
+$ %s tx poa add-validator <address> --from=<key_or_address>
 `,
 				version.AppName,
 			),
@@ -92,7 +93,7 @@ func NewSubmitRemoveValidatorProposalTxCmd() *cobra.Command {
 			fmt.Sprintf(`Submit an RemoveValidator proposal
 
 Example:
-$ %s tx gov submit-proposal remove-validator <address> --from=<key_or_address>
+$ %s tx poa remove-validator <address> --from=<key_or_address>
 `,
 				version.AppName,
 			),


### PR DESCRIPTION
# TXC-02: Fix Inaccurate Examples in `NewSubmitAddValidatorProposalTxCmd` and `NewSubmitRemoveValidatorProposalTxCmd` PR

## Issues :1st_place_medal: 
- [TXC-02 | Inaccurate Examples in `NewSubmitAddValidatorProposalTxCmd` and `NewSubmitRemoveValidatorProposalTxCmd`](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=3285da01e8804b65b592270ee8f442f1&pm=s) ([Audit link](https://skyharbor.certik.com/shared-report/4130da9b-fd86-421f-8b64-0d1bdc6bd1d8?findingIndex=TXC-02))

## Changes :hammer_and_wrench: 
- Fix both examples