### PR TITLE
[TA-2513] KEK-04: Init PoA Module Account

### DIFF
--- a/x/poa/module.go
+++ b/x/poa/module.go
@@ -137,6 +137,9 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.Ra
 
 	am.keeper.InitGenesis(ctx, genState)
 
+	// To create module account
+	am.ak.GetModuleAccount(ctx, am.Name())
+
 	return []abci.ValidatorUpdate{}
 }
 

--- a/x/poa/types/expected_keepers.go
+++ b/x/poa/types/expected_keepers.go
@@ -10,6 +10,7 @@ import (
 // AccountKeeper defines the expected account keeper used for simulations (noalias)
 type AccountKeeper interface {
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI
+	GetModuleAccount(ctx sdk.Context, moduleName string) types.ModuleAccountI
 	// Methods imported from account should be defined here
 }
 


### PR DESCRIPTION
# KEK-04: Init PoA Module Account PR

## Issues :1st_place_medal: 
- [KEK-04 | PoA Module Could Be Disabled As PoA Module Account Has Not Been Initialized](https://www.notion.so/1930f38fb1e94f82845dab04ac1caeca?v=64f1d5da841741cf9cb3b831e5b493e3&p=d789988bc0c84ccca094e4e74811842a&pm=s) ([Audit link](https://skyharbor.certik.com/shared-report/4130da9b-fd86-421f-8b64-0d1bdc6bd1d8?findingIndex=KEK-04))

## Changes :hammer_and_wrench: 
- Init poa module account on InitGenesis