### PR TITLE
[FIX] Add tm ibc client to fix v2 upgrade

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,6 +7,7 @@ import (
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	ethante "github.com/evmos/evmos/v15/app/ante/evm"
+	"github.com/spf13/cast"
 	"io"
 	"os"
 	"path/filepath"
@@ -103,8 +104,7 @@ import (
 	ibcporttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
-	"github.com/spf13/cast"
-
+	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
 	"github.com/Peersyst/exrp/docs"
@@ -172,6 +172,7 @@ var (
 		slashing.AppModuleBasic{},
 		feegrantmodule.AppModuleBasic{},
 		ibc.AppModuleBasic{},
+		ibctm.AppModuleBasic{},
 		upgrade.AppModuleBasic{},
 		evidence.AppModuleBasic{},
 		transfer.AppModuleBasic{},

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ replace (
 	// use Evmos geth fork
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc2
 	// use exrp Evmos fork
-	github.com/evmos/evmos/v15 => github.com/Peersyst/evmos/v15 v15.0.0-exrp.1
+	github.com/evmos/evmos/v15 => github.com/Peersyst/evmos/v15 v15.0.0-exrp.2
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// replace broken goleveldb

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2y
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Peersyst/evmos/v15 v15.0.0-exrp.1 h1:hZo97kG5OIKacTd3cTfWXwZAX3bXOEnfZP0bgVdjVAw=
-github.com/Peersyst/evmos/v15 v15.0.0-exrp.1/go.mod h1:15ZOo7jqFRe5elw2ipTb3oHq3x7rebUjwq4y2vJEj4Q=
+github.com/Peersyst/evmos/v15 v15.0.0-exrp.2 h1:tvBzN2PbH+zH6mW3TI2oJs4SE6qdubXCWc+vtN/q95c=
+github.com/Peersyst/evmos/v15 v15.0.0-exrp.2/go.mod h1:15ZOo7jqFRe5elw2ipTb3oHq3x7rebUjwq4y2vJEj4Q=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=


### PR DESCRIPTION
# Add tm ibc client to fix v2 upgrade

## Motivation 💡

Upgrade to V2 was breaking due to the lack of an IBC module

## Changes 🛠

- Add IBC tendermint light client `"github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"` in the AppModules