### PR TITLE
[FIX] Disable authz staking messages

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -756,6 +756,10 @@ func (app *App) setAnteHandler(txConfig client.TxConfig, maxGasWanted uint64) {
 		MaxTxGasWanted:         maxGasWanted,
 		TxFeeChecker:           ethante.NewDynamicFeeChecker(app.EvmKeeper),
 		ExtraDecorator:         poaante.NewPoaDecorator(),
+		AuthzDisabledMsgTypes: []string{
+			sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
+		},
 	}
 
 	if err := options.Validate(); err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -7,6 +7,7 @@ import (
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	ethante "github.com/evmos/evmos/v15/app/ante/evm"
+	"github.com/spf13/cast"
 	"io"
 	"os"
 	"path/filepath"
@@ -103,8 +104,7 @@ import (
 	ibcporttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
-	"github.com/spf13/cast"
-
+	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
 	"github.com/Peersyst/exrp/docs"
@@ -172,6 +172,7 @@ var (
 		slashing.AppModuleBasic{},
 		feegrantmodule.AppModuleBasic{},
 		ibc.AppModuleBasic{},
+		ibctm.AppModuleBasic{},
 		upgrade.AppModuleBasic{},
 		evidence.AppModuleBasic{},
 		transfer.AppModuleBasic{},

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ replace (
 	// use Evmos geth fork
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc2
 	// use exrp Evmos fork
-	github.com/evmos/evmos/v15 => github.com/Peersyst/evmos/v15 v15.0.0-exrp.1
+	github.com/evmos/evmos/v15 => github.com/Peersyst/evmos/v15 v15.0.0-exrp.2
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// replace broken goleveldb

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ replace (
 	// use Evmos geth fork
 	github.com/ethereum/go-ethereum => github.com/evmos/go-ethereum v1.10.26-evmos-rc2
 	// use exrp Evmos fork
-	github.com/evmos/evmos/v15 => github.com/Peersyst/evmos/v15 v15.0.0-exrp.2
+	github.com/evmos/evmos/v15 => github.com/Peersyst/evmos/v15 v15.0.0-exrp.3
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// replace broken goleveldb

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2y
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Peersyst/evmos/v15 v15.0.0-exrp.1 h1:hZo97kG5OIKacTd3cTfWXwZAX3bXOEnfZP0bgVdjVAw=
-github.com/Peersyst/evmos/v15 v15.0.0-exrp.1/go.mod h1:15ZOo7jqFRe5elw2ipTb3oHq3x7rebUjwq4y2vJEj4Q=
+github.com/Peersyst/evmos/v15 v15.0.0-exrp.2 h1:tvBzN2PbH+zH6mW3TI2oJs4SE6qdubXCWc+vtN/q95c=
+github.com/Peersyst/evmos/v15 v15.0.0-exrp.2/go.mod h1:15ZOo7jqFRe5elw2ipTb3oHq3x7rebUjwq4y2vJEj4Q=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2y
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Peersyst/evmos/v15 v15.0.0-exrp.2 h1:tvBzN2PbH+zH6mW3TI2oJs4SE6qdubXCWc+vtN/q95c=
-github.com/Peersyst/evmos/v15 v15.0.0-exrp.2/go.mod h1:15ZOo7jqFRe5elw2ipTb3oHq3x7rebUjwq4y2vJEj4Q=
+github.com/Peersyst/evmos/v15 v15.0.0-exrp.3 h1:aPaHhkx1YTZ7gl/fTXjhXFP4wYWf/n4ecSWiB333Gas=
+github.com/Peersyst/evmos/v15 v15.0.0-exrp.3/go.mod h1:15ZOo7jqFRe5elw2ipTb3oHq3x7rebUjwq4y2vJEj4Q=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/x/poa/ante/poa.go
+++ b/x/poa/ante/poa.go
@@ -3,6 +3,7 @@ package ante
 import (
 	"errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 type PoaDecorator struct{}
@@ -14,8 +15,8 @@ func NewPoaDecorator() PoaDecorator {
 func (cbd PoaDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	// loop through all the messages and check if the message type is allowed
 	for _, msg := range tx.GetMsgs() {
-		if sdk.MsgTypeURL(msg) == "/cosmos.staking.v1beta1.MsgUndelegate" ||
-			sdk.MsgTypeURL(msg) == "/cosmos.staking.v1beta1.MsgBeginRedelegate" {
+		if sdk.MsgTypeURL(msg) == sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}) ||
+			sdk.MsgTypeURL(msg) == sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}) {
 			return ctx, errors.New("tx type not allowed")
 		}
 	}


### PR DESCRIPTION
# [FIX] Disable authz staking messages

## Motivation 💡

Certik team found another issue related with the KEK-03 fix made in https://github.com/Peersyst/exrp/pull/16

_The finding KEK-03: Insufficient Check When Adding And Removing Validator In poa Module is updated as partially resolved with a Proof of Concept. The newly added antehandler  in poa module to disable unbond and redelegate is intended to restrict the validator from moving the apoa token around, while this validation could be enhanced to disable them from being executed in authz transaction.  To enhance the validation, recommend adding the two disabled messages `MsgUndelegate` and `MsgBeginRedelegate` to the antehandler `NewAuthzLimiterDecorator()` to disable them being nested in the authz transaction._

## Changes 🛠

- Change evmos version to include AuthzDisableMsgTypes ante handler option (https://github.com/Peersyst/evmos/commit/b497d89858e4f77345b68c7147d771cec2fad34a)
- Include `MsgUndelegate` and `MsgBeginRedelegate` in the AuthzDisableMsgTypes
- Change hardcoded staking msg types in poa ante handler `x/poa/ante/poa.go`

