### PR TITLE
fix: pass initialized GovKeeper to gov precompile instead of zero-value

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -458,6 +458,29 @@ func New(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
+	govConfig := govtypes.DefaultConfig()
+	govKeeper := govkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[govtypes.StoreKey]),
+		app.AccountKeeper,
+		app.BankKeeper,
+		stakingKeeper,
+		app.DistrKeeper,
+		app.MsgServiceRouter(),
+		govConfig,
+		authAddress,
+	)
+	govRouter := govv1beta1.NewRouter()
+	govRouter.
+		AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper))
+	// Set legacy router for backwards compatibility with gov v1beta1
+	govKeeper.SetLegacyRouter(govRouter)
+
+	app.GovKeeper = *govKeeper.SetHooks(
+		govtypes.NewMultiGovHooks(),
+	)
+
 	// Ethermint keepers
 
 	// Feemarket Keeper
@@ -556,29 +579,6 @@ func New(
 	)
 	// If evidence needs to be handled for the app, set routes in router here and seal
 	app.EvidenceKeeper = *evidenceKeeper
-
-	govConfig := govtypes.DefaultConfig()
-	govKeeper := govkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[govtypes.StoreKey]),
-		app.AccountKeeper,
-		app.BankKeeper,
-		stakingKeeper,
-		app.DistrKeeper,
-		app.MsgServiceRouter(),
-		govConfig,
-		authAddress,
-	)
-	govRouter := govv1beta1.NewRouter()
-	govRouter.
-		AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper))
-	// Set legacy router for backwards compatibility with gov v1beta1
-	govKeeper.SetLegacyRouter(govRouter)
-
-	app.GovKeeper = *govKeeper.SetHooks(
-		govtypes.NewMultiGovHooks(),
-	)
 
 	/**** IBC Routing ****/
 


### PR DESCRIPTION
# fix: pass initialized GovKeeper to gov precompile instead of zero-value

## Motivation 💡

`DefaultStaticPrecompiles` was called during `EvmKeeper` construction with `app.GovKeeper` passed by value. At that point `app.GovKeeper` had not yet been assigned, so the gov precompile received a copy of the zero-value `govkeeper.Keeper` (nil store service, nil codec, nil router, etc.). Because `WithGovPrecompile` takes the address of its local copy to pass to `NewMsgServerImpl` and `NewQueryServer`, the precompile permanently held a pointer to that nil-field keeper even after `app.GovKeeper` was properly initialized later in `NewApp`.

## Changes 🛠

- Move `app.GovKeeper` initialization before the `EvmKeeper` construction in `app/app.go`, so `DefaultStaticPrecompiles` receives a fully initialized keeper.

## Considerations 🤔

- All dependencies of `govkeeper.NewKeeper` (`AccountKeeper`, `BankKeeper`, `StakingKeeper`, `DistrKeeper`, `ParamsKeeper`) are initialized well before the new position without circular dependency risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module initialization sequence to improve code structure and ensure proper dependency ordering.

**Note:** This release contains internal code restructuring with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->