### PR TITLE
fix: enforce rate limit on outbound ibc transfers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -505,17 +505,6 @@ func New(
 		&app.TransferKeeper,
 	)
 
-	// Create the rate limit keeper
-	app.RateLimitKeeper = *ratelimitkeeper.NewKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
-		app.GetSubspace(ratelimittypes.ModuleName),
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		app.BankKeeper,
-		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.ClientKeeper,
-		app.IBCKeeper.ChannelKeeper, // ICS4Wrapper
-	)
 	// Create Transfer Keepers
 	app.TransferKeeper = transferkeeper.NewKeeper(
 		appCodec,
@@ -529,6 +518,20 @@ func New(
 		authAddress,
 	)
 	app.TransferKeeper.SetAddressCodec(evmaddress.NewEvmCodec(sdk.GetConfig().GetBech32AccountAddrPrefix()))
+
+	// Create the rate limit keeper
+	app.RateLimitKeeper = *ratelimitkeeper.NewKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[ratelimittypes.StoreKey]),
+		app.GetSubspace(ratelimittypes.ModuleName),
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		app.BankKeeper,
+		app.IBCKeeper.ChannelKeeper,
+		app.IBCKeeper.ClientKeeper,
+		app.IBCKeeper.ChannelKeeper, // ICS4Wrapper
+	)
+
+	app.TransferKeeper.WithICS4Wrapper(&app.RateLimitKeeper)
 
 	transferModule := transfer.NewAppModule(app.TransferKeeper)
 	// Create the app.ICAHostKeeper
@@ -587,16 +590,15 @@ func New(
 		Create Transfer Stack
 
 		transfer stack contains (from bottom to top):
-			- ERC-20 Middleware
-		 	- Recovery Middleware
-		 	- Airdrop Claims Middleware
 			- IBC Transfer
+			- Rate Limit Middleware
+			- ERC-20 Middleware
 
 		SendPacket, since it is originating from the application to core IBC:
-		 	transferKeeper.SendPacket -> claim.SendPacket -> recovery.SendPacket -> erc20.SendPacket -> channel.SendPacket
+			transferKeeper.SendPacket -> rateLimitKeeper.SendPacket -> channel.SendPacket
 
 		RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
-			channel.RecvPacket -> erc20.OnRecvPacket -> recovery.OnRecvPacket -> claim.OnRecvPacket -> transfer.OnRecvPacket
+			channel.RecvPacket -> erc20.OnRecvPacket -> rateLimit.OnRecvPacket -> transfer.OnRecvPacket
 	*/
 
 	// create IBC module from top to bottom of stack


### PR DESCRIPTION
# fix: enforce rate limit on outbound ibc transfers

## Motivation 💡

`TransferKeeper` was constructed with `app.IBCKeeper.ChannelKeeper` as its `ICS4Wrapper`, so outbound transfers called `transfer.SendPacket -> channel.SendPacket` directly, completely bypassing the rate-limit middleware. Rate limiting only applied to inbound packets (via the `IBCModule` middleware chain), leaving the outbound path unprotected.

## Changes 🛠

- Moved `RateLimitKeeper` initialization to run after `TransferKeeper` creation
- Wired the outbound stack with `app.TransferKeeper.WithICS4Wrapper(&app.RateLimitKeeper)` so outbound transfers flow through rate limiting before reaching the channel
- Updated the stale transfer-stack doc comment to reflect the real layers (IBC Transfer, Rate Limit, ERC-20), removing references to `recovery` and `claims` middlewares

## Considerations 🤔

- Outbound chain is now `transferKeeper.SendPacket -> rateLimitKeeper.SendPacket -> channel.SendPacket`. Inbound chain remains `channel.RecvPacket -> erc20.OnRecvPacket -> rateLimit.OnRecvPacket -> transfer.OnRecvPacket`.
- `WithICS4Wrapper` is called before `transfer.NewAppModule` and `transfer.NewIBCModule`, which take the keeper by value, so the module copies observe the correct `ics4Wrapper`. `Erc20Keeper` holds a pointer to `TransferKeeper`, so it also sees the updated wiring.
- Passed `&app.RateLimitKeeper` (pointer) rather than a value copy to preserve identity and future-proof against later mutations of the keeper. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limiting behavior for IBC transfers by reordering middleware initialization to ensure rate limits are properly enforced at the appropriate layer.

* **Documentation**
  * Updated internal documentation to reflect the current middleware stack architecture and transfer processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->