### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -20,16 +20,16 @@ jobs:
         steps:
             - name: Retrieve branch name
               run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-            - uses: actions/checkout@v2
-            - uses: docker/setup-qemu-action@v2
-            - uses: docker/setup-buildx-action@v2
-            - uses: docker/login-action@v2
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+            - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+            - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
               with:
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PUSH_TOKEN }}
             # Build and push docker image
             - name: Build docker image
-              uses: docker/build-push-action@v4
+              uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
               with:
                   target: release
                   push: true

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -34,5 +34,3 @@ jobs:
                   target: release
                   push: true
                   tags: peersyst/exrp:${{ env.BRANCH }}
-                  secrets: |
-                    ssh_key_b64=${{ secrets.SSH_KEY_B64 }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -29,8 +29,10 @@ jobs:
                   password: ${{ secrets.DOCKER_PUSH_TOKEN }}
             # Build and push docker image
             - name: Build docker image
-              uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+              uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
               with:
                   target: release
                   push: true
+                  provenance: false
+                  sbom: false
                   tags: peersyst/exrp:${{ env.BRANCH }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -5,6 +5,8 @@ on:
         branches:
             - "main"
 
+permissions: {}
+
 concurrency:
   # Cancel old runs if there is a new commit in the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,6 +15,8 @@ concurrency:
 jobs:
     integration:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Retrieve branch name
               run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV

--- a/.github/workflows/cosmovisor.yml
+++ b/.github/workflows/cosmovisor.yml
@@ -25,10 +25,12 @@ jobs:
           password: ${{ secrets.DOCKER_PUSH_TOKEN }}
       # Build and push docker image
       - name: Build docker image
-        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: tools/cosmovisor/Dockerfile
           push: true
+          provenance: false
+          sbom: false
           tags: |
             peersyst/exrp-cosmovisor:${{ github.event.inputs.tag }}
             peersyst/exrp-cosmovisor:latest

--- a/.github/workflows/cosmovisor.yml
+++ b/.github/workflows/cosmovisor.yml
@@ -7,9 +7,13 @@ on:
         description: The docker tag for the publish
         required: true
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v2

--- a/.github/workflows/cosmovisor.yml
+++ b/.github/workflows/cosmovisor.yml
@@ -15,17 +15,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       # Docker login
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_TOKEN }}
       # Build and push docker image
       - name: Build docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           file: tools/cosmovisor/Dockerfile
           push: true

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,13 +22,13 @@ jobs:
     steps:
       - name: Free disk space
         run: rm -rf /opt/hostedtoolcache
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.commit_branch }}
           fetch-depth: 0
           fetch-tags: true
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       # Build and push docker image
       - name: Run go releaser
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -12,9 +12,13 @@ on:
         description: The branch or the commit sha to push tag to
         required: true
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Free disk space
         run: rm -rf /opt/hostedtoolcache

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,19 +25,11 @@ jobs:
           fetch-tags: true
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      # Configure SSH for private Go modules
-      - name: Setup SSH for private modules
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_KEY_B64 }}" | base64 -d > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
       # Build and push docker image
       - name: Run go releaser
         run: |
-          docker run --rm -e CGO_ENABLED -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} -e GOPRIVATE=github.com/xrplevm/evm-sec-papyrus\
+          docker run --rm -e CGO_ENABLED -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
              -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/go/src/exrp -w /go/src/exrp \
-             -v ~/.ssh:/root/.ssh:ro \
              --entrypoint /bin/sh \
              goreleaser/goreleaser-cross:v1.22 -c \
-             'git config --global --add safe.directory /go/src/exrp && git config --global url."ssh://git@github.com/xrplevm/evm-sec-papyrus".insteadOf "https://github.com/xrplevm/evm-sec-papyrus" && goreleaser release --clean --skip validate'
+             'git config --global --add safe.directory /go/src/exrp && goreleaser release --clean --skip validate'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,8 @@ on:
     pull_request:
         types: [opened, synchronize]
 
+permissions: {}
+
 concurrency:
     # Cancel old runs if there is a new commit in the same branch
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +14,8 @@ concurrency:
 jobs:
     integration:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             -   uses: actions/checkout@v2
             -   uses: docker/setup-qemu-action@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,12 +17,12 @@ jobs:
         permissions:
             contents: read
         steps:
-            -   uses: actions/checkout@v2
-            -   uses: docker/setup-qemu-action@v2
-            -   uses: docker/setup-buildx-action@v2
+            -   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+            -   uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+            -   uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
             # Build docker image
             - name: Build docker image
-              uses: docker/build-push-action@v4
+              uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
               with:
                   context: .
                   target: integration

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,8 +22,10 @@ jobs:
             -   uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
             # Build docker image
             - name: Build docker image
-              uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+              uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
               with:
                   context: .
                   target: integration
                   push: false
+                  provenance: false
+                  sbom: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,5 +27,3 @@ jobs:
                   context: .
                   target: integration
                   push: false
-                  secrets: |
-                      ssh_key_b64=${{ secrets.SSH_KEY_B64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
           tags: |
             peersyst/exrp:${{ github.event.inputs.tag }}
             ${{ fromJSON('["", "peersyst/exrp:latest"]')[github.event.inputs.is_latest_release == 'true'] }}
-          secrets: |
-            ssh_key_b64=${{ secrets.SSH_KEY_B64 }}
       - name: Publish the Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.commit_branch }}
           fetch-depth: 0
           fetch-tags: true
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Free disk space
         run: rm -rf /opt/hostedtoolcache
       # Docker login
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
       # Build and push docker image
       - name: Build docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           target: release
@@ -51,7 +51,7 @@ jobs:
           secrets: |
             ssh_key_b64=${{ secrets.SSH_KEY_B64 }}
       - name: Publish the Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.event.inputs.tag }}
           prerelease: steps.check-prerelease.outputs.match == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,13 @@ on:
         description: Is this the latest release
         type: boolean
         required: true
-permissions:
-  contents: write
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +60,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   goreleaser:
     needs: [ release ]
+    permissions:
+      contents: write
     uses: ./.github/workflows/goreleaser.yml
     secrets: inherit
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,13 @@ jobs:
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
       # Build and push docker image
       - name: Build docker image
-        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           target: release
           push: true
+          provenance: false
+          sbom: false
           build-args: VERSION=${{ env.VERSION }}
           tags: |
             peersyst/exrp:${{ github.event.inputs.tag }}

--- a/.github/workflows/unit-coverage.yml
+++ b/.github/workflows/unit-coverage.yml
@@ -4,10 +4,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ '**' ]
+
+permissions: {}
+
 jobs:
   build:
     name: Unit test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/unit-coverage.yml
+++ b/.github/workflows/unit-coverage.yml
@@ -14,14 +14,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-      
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+
       - name: Generate unit test coverage
         run: make coverage-unit
 
       - name: Check unit test coverage
-        uses: vladopajic/go-test-coverage@v2
+        uses: vladopajic/go-test-coverage@f190f667e23b4441202d0bab0f8c2e7bce8925b6 # v2.18.4
         with:
           # Configure action using config file (option 1)
           config: ./.testcoverage.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,6 @@ RUN apt update && \
 WORKDIR /app
 COPY . .
 
-# Hotfix to allow download of private go module
-ENV GOPRIVATE=github.com/xrplevm/evm-sec-papyrus
-RUN mkdir -p ~/.ssh
-RUN --mount=type=secret,id=ssh_key_b64 base64 -d -i /run/secrets/ssh_key_b64 > ~/.ssh/id_rsa
-RUN chmod 600 ~/.ssh/id_rsa
-RUN ssh-keyscan github.com >> ~/.ssh/known_hosts
-RUN git config --global url."ssh://git@github.com/xrplevm/evm-sec-papyrus".insteadOf "https://github.com/xrplevm/evm-sec-papyrus"
-
 RUN make install
 
 


### PR DESCRIPTION
# ci: harden GitHub Actions workflows

## Motivation 💡

- Workflows ran with the default (broad) `GITHUB_TOKEN` permissions and pulled third-party actions by floating tags (`@v2`, `@v3`, `@v4`), leaving CI exposed to token misuse and upstream tag hijacking.
- The SSH-based workaround for the private `xrplevm/evm-sec-papyrus` Go module is no longer required and was leaking an SSH key into the build environment and the released Docker image.

## Changes 🛠

- Locked down `GITHUB_TOKEN` scope across all workflows 
  - Added a top-level `permissions: {}` (deny-all) to `branch.yml`, `cosmovisor.yml`, `goreleaser.yml`, `pull-request.yml`, `release.yml` and `unit-coverage.yml`.
  - Granted per-job least-privilege scopes: `contents: read` for build/test jobs and `contents: write` only for `release` / `goreleaser` jobs that publish tags and releases.
- Pinned every third-party action to a full commit SHA with a trailing `# vX.Y.Z` comment 
  - `actions/checkout`, `actions/setup-go`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/build-push-action`, `softprops/action-gh-release`, `vladopajic/go-test-coverage`.
  - Bumped majors where applicable (checkout v2 -> v6, setup-go v3 -> v6, docker/setup-qemu + docker/setup-buildx + docker/login v2/v4 -> v4, docker/build-push-action v4 -> v7, action-gh-release v1 -> v3).
  - Disabled default provenance / SBOM attestations on every `docker/build-push-action` step (`provenance: false`, `sbom: false`) so the v7 bump keeps the same image manifest shape v4.2.1 produced. Downstream consumers pulling these images see a single-manifest image, not a multi-manifest index with extra attestation artifacts.
- Dropped the private Go module SSH plumbing 
  - Removed the `Setup SSH for private modules` step and `~/.ssh` mount from `goreleaser.yml`.
  - Removed the `ssh_key_b64` build secret from `branch.yml`, `pull-request.yml` and `release.yml`.
  - Removed the `GOPRIVATE` / `ssh_key_b64` / `ssh-keyscan` / `git config insteadOf` block from the `Dockerfile`.

## Considerations 

- `SSH_KEY_B64` and the `GOPRIVATE` override are no longer referenced by any workflow or the Dockerfile, so the `SSH_KEY_B64` repository secret can be revoked once this lands.
- SHA pins must be refreshed when we want a newer action version.
- Scopes were set to the minimum needed today. If a future job needs to push packages, open PRs, or write checks, it will have to opt-in explicitly at the job level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD actions pinned for more deterministic, reproducible builds.
  * Workflow permissions tightened to reduce token access scope.
  * Build process no longer injects SSH secrets and no longer emits SBOM/provenance artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->