### PR TITLE
fix: remove erc20types duplicate

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -751,7 +751,6 @@ func New(
 		feegrant.ModuleName,
 		upgradetypes.ModuleName,
 		// Evmos
-		erc20types.ModuleName,
 		poatypes.ModuleName,
 		crisistypes.ModuleName,
 		ratelimittypes.ModuleName,


### PR DESCRIPTION
# fix: remove erc20types duplicate

## Motivation 💡

`erc20types.ModuleName` was listed twice in `genesisModuleOrder` in `app/app.go`. Cosmos SDK's module manager rejects duplicate module names when setting init/export genesis order, which would fail on node startup.

## Changes 🛠

- Removed the duplicate `erc20types.ModuleName` entry from `genesisModuleOrder` in `app/app.go` (the canonical entry earlier in the list is preserved)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted ERC20 module ordering during genesis initialization and export to optimize the sequence of module operations during blockchain initialization and state export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->