### PR TITLE
chore: pin Dockerfile base image to SHA256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.8 AS base
+FROM golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59 AS base
 USER root
 RUN apt update && \
     apt-get install -y \
@@ -36,7 +36,7 @@ RUN make test-integration
 
 RUN touch /test.lock
 
-FROM golang:1.23.8 AS release
+FROM golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59 AS release
 WORKDIR /
 COPY --from=integration /test.lock /test.lock
 COPY --from=build /app/bin/exrpd /usr/bin/exrpd


### PR DESCRIPTION
# chore: pin Dockerfile base image to SHA256 digest

## Motivation 💡

The Dockerfile pinned the Go base image by tag only (`golang:1.23.8`). Tags on Docker Hub are mutable: the same tag can be re-pushed with different layers by the publisher or via a supply-chain compromise, which would silently land in every image published to `peersyst/exrp`. Pinning by digest makes the base image content-addressed and immutable per build.

## Changes 🛠

- Pinned the `base` stage to `golang:1.23.8@sha256:ec5612bbd9e96d5b80a8b968cea06a4a9b985fe200ff6da784bf607063273c59`
- Pinned the `release` stage to the same digest so the final image userspace and CA bundle match the build stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build image versioning to improve reproducibility and build consistency.
  * Fixed end-of-file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->