### PR TITLE
fix: remove keyring-backend=test default override

### DIFF
--- a/cmd/exrpd/cmd/root.go
+++ b/cmd/exrpd/cmd/root.go
@@ -41,12 +41,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
-	"github.com/spf13/cast"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	evmclient "github.com/cosmos/evm/client"
 	ethermintservercfg "github.com/cosmos/evm/server/config"
+	"github.com/spf13/cast"
+	"github.com/spf13/cobra"
 	"github.com/xrplevm/node/v10/app"
 )
 
@@ -277,23 +275,6 @@ func txCommand() *cobra.Command {
 func addModuleInitFlags(startCmd *cobra.Command) {
 	crisis.AddModuleInitFlags(startCmd)
 	// this line is used by starport scaffolding # root/arguments
-}
-
-func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
-	set := func(s *pflag.FlagSet, key, val string) {
-		if f := s.Lookup(key); f != nil {
-			f.DefValue = val
-			//nolint:errcheck
-			f.Value.Set(val)
-		}
-	}
-	for key, val := range defaults {
-		set(c.Flags(), key, val)
-		set(c.PersistentFlags(), key, val)
-	}
-	for _, c := range c.Commands() {
-		overwriteFlagDefaults(c, defaults)
-	}
 }
 
 type appCreator struct {

--- a/cmd/exrpd/cmd/root.go
+++ b/cmd/exrpd/cmd/root.go
@@ -159,10 +159,6 @@ func NewRootCmd() (*cobra.Command, sdktestutil.TestEncodingConfig) {
 		panic(err)
 	}
 
-	overwriteFlagDefaults(rootCmd, map[string]string{
-		flags.FlagKeyringBackend: "test",
-	})
-
 	return rootCmd, encodingConfig
 }
 


### PR DESCRIPTION
# fix: remove keyring-backend=test default override

## Motivation 💡

The root command was globally overriding the keyring backend default to `test` across all subcommands, including production node operations. The `test` backend stores keys as unencrypted JSON files under `~/.exrpd/keyring-test/` with no passphrase protection, so any operator running the binary without explicitly passing `--keyring-backend=os` would silently use the insecure backend. This exposes Cosmos-managed keys (e.g. hot wallet keys for fee payments or EVM operations) to any attacker with local filesystem access.

## Changes 🛠

- Removed the `overwriteFlagDefaults` call in `cmd/exrpd/cmd/root.go` that set `flags.FlagKeyringBackend` to `test`, restoring the Cosmos SDK default of `os` (OS secret store).

## Considerations 🤔

- Operators who were relying on the implicit `test` backend will need to either pass `--keyring-backend=test` explicitly for local development or migrate their keys to the `os` backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an automatic override that forced the keyring backend to a test value. The flag now respects its intended default and configured value across the command tree, preventing unexpected test-mode behavior and restoring proper runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->