### PR TITLE
fix: replace hardcoded EVM chain ID fallback with proper error handling

### DIFF
--- a/cmd/exrpd/cmd/root.go
+++ b/cmd/exrpd/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -139,7 +140,10 @@ func NewRootCmd() (*cobra.Command, sdktestutil.TestEncodingConfig) {
 
 			chainID, err := CosmosChainIDToEvmChainID(initClientCtx.ChainID)
 			if err != nil {
-				chainID = 9999
+				if initClientCtx.ChainID != "" {
+					return fmt.Errorf("invalid chain ID format %q: %w", initClientCtx.ChainID, err)
+				}
+				chainID = 0
 			}
 			customAppTemplate, customAppConfig := InitAppConfig(app.BaseDenom, chainID)
 			customTMConfig := initTendermintConfig()


### PR DESCRIPTION
# fix: replace hardcoded EVM chain ID fallback with proper error handling

## Motivation 💡

`cmd/exrpd/cmd/root.go` silently fell back to a hardcoded EVM chain ID of `9999` whenever `CosmosChainIDToEvmChainID(initClientCtx.ChainID)` returned an error, including when the operator had explicitly configured an invalid chain ID. A typo or malformed chain ID would still let the node boot under chain `9999`, masking the misconfiguration instead of failing fast.

## Changes 🛠

- When `CosmosChainIDToEvmChainID` fails and `initClientCtx.ChainID` is non-empty, return `fmt.Errorf("invalid chain ID format %q: %w", initClientCtx.ChainID, err)` so the misconfiguration surfaces at startup.
- When `initClientCtx.ChainID` is empty (early init paths before a chain ID has been set), default `chainID` to `0` instead of `9999`, removing the magic sentinel.
## Considerations 🤔

- The empty-chain-id branch now passes `0` (instead of `9999`) into `InitAppConfig` for template generation. This only affects config defaults emitted before a real chain ID is configured, and is overwritten as soon as one is set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain ID validation to properly report errors when an invalid chain ID is provided, rather than silently falling back to a default value. The system now only uses default fallback behavior when a chain ID is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->