### PR TITLE
chore: replace ibc-go pseudo-version with tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cosmos/gogoproto v1.7.2
 	github.com/cosmos/ibc-apps/modules/rate-limiting/v10 v10.1.0
 	github.com/cosmos/ibc-go/modules/capability v1.0.1
-	github.com/cosmos/ibc-go/v10 v10.3.1-0.20250909102629-ed3b125c7b6f
+	github.com/cosmos/ibc-go/v10 v10.4.0
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,8 @@ github.com/cosmos/ibc-apps/modules/rate-limiting/v10 v10.1.0 h1:Wpa3gDW2tNxxdcUz
 github.com/cosmos/ibc-apps/modules/rate-limiting/v10 v10.1.0/go.mod h1:0NWhkh5Ok8t/qHWOn8LUZsG5rTxhwQWyrsI3xu1/PO0=
 github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9svjthrX2+oXdZvzgGI=
 github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
-github.com/cosmos/ibc-go/v10 v10.3.1-0.20250909102629-ed3b125c7b6f h1:I5t5Tuewh6E9icYCtS4aSwyzIEvr2iBods08Hq+GBME=
-github.com/cosmos/ibc-go/v10 v10.3.1-0.20250909102629-ed3b125c7b6f/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
+github.com/cosmos/ibc-go/v10 v10.4.0 h1:dPMtBw1vb/CdXQuiue+JfGwS/BYbbEFJaeSVFx86nMw=
+github.com/cosmos/ibc-go/v10 v10.4.0/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5RtnU=
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=


### PR DESCRIPTION
# chore: replace ibc-go pseudo-version with v10.4.0 tag

## Motivation 💡

`go.mod` was pinned to the ibc-go pseudo-version `v10.3.1-0.20250909102629-ed3b125c7b6f`. Upstream has since tagged that exact commit (`ed3b125c7b6fb7cbb6f9535d62f4c19f572a0c53`) as `v10.4.0`, so we can switch to a stable release tag instead of a pseudo-version.

## Changes 🛠

- Bumped `github.com/cosmos/ibc-go/v10` from `v10.3.1-0.20250909102629-ed3b125c7b6f` to `v10.4.0` in `go.mod`
- Refreshed the matching `go.sum` entries

## Considerations 🤔

- No code change: the pseudo-version and `v10.4.0` resolve to the same upstream commit (`ed3b125c7b6f`) and the `go.mod` sum (`h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=`) is unchanged, so this is a label-only swap

```
❯ go list -m -json github.com/cosmos/ibc-go/v10@v10.3.1-0.20250909102629-ed3b125c7b6f
{
        "Path": "github.com/cosmos/ibc-go/v10",
        "Version": "v10.3.1-0.20250909102629-ed3b125c7b6f",
        "Time": "2025-09-09T10:26:29Z",
        "Dir": "/home/kevin/go/pkg/mod/github.com/cosmos/ibc-go/v10@v10.3.1-0.20250909102629-ed3b125c7b6f",
        "GoMod": "/home/kevin/go/pkg/mod/cache/download/github.com/cosmos/ibc-go/v10/@v/v10.3.1-0.20250909102629-ed3b125c7b6f.mod",
        "GoVersion": "1.23.8",
        "Sum": "h1:I5t5Tuewh6E9icYCtS4aSwyzIEvr2iBods08Hq+GBME=",
        "GoModSum": "h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=",
        "Origin": {
                "VCS": "git",
                "URL": "https://github.com/cosmos/ibc-go",
                "Hash": "ed3b125c7b6fb7cbb6f9535d62f4c19f572a0c53"
        }
}
❯ git ls-remote --tags https://github.com/cosmos/ibc-go.git | grep ed3b125c7b6f
ed3b125c7b6fb7cbb6f9535d62f4c19f572a0c53        refs/tags/v10.4.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the inter-blockchain communication protocol module dependency from a development pre-release build to the latest official stable release version. This important update provides direct access to official support channels, security patches, essential bug fixes, latest protocol improvements, and ensures long-term stability along with comprehensive maintenance support for system operations moving forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->