### PR TITLE
ci: harden TAG input to prevent shell injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_TOKEN }}
-      - run: |
-          TAG=${{ github.event.inputs.tag }}
+      - name: Parse version
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
       # Build and push docker image
       - name: Build docker image


### PR DESCRIPTION
# ci: harden TAG input to prevent shell injection

## Motivation 💡

The release workflow interpolated `github.event.inputs.tag` directly into a shell `run:` block. Because workflow_dispatch inputs are user-controlled, a crafted tag value could break out of the script and execute arbitrary commands on the runner, which has access to the Docker Hub push credentials.

## Changes 🛠

- In `.github/workflows/release.yml`, moved the `tag` input out of `${{ ... }}` interpolation and into an `env:` block (`TAG: ${{ github.event.inputs.tag }}`), so the shell sees it as a regular environment variable instead of as inlined script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build automation process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->