### PR TITLE
fix: validate extension options in EVM ante handler

### DIFF
--- a/app/ante/evm_handler.go
+++ b/app/ante/evm_handler.go
@@ -3,15 +3,24 @@ package ante
 import (
 	baseevmante "github.com/cosmos/evm/ante"
 	evmante "github.com/cosmos/evm/ante/evm"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 )
+
+func isEthereumTxExtensionOption(anyType *codectypes.Any) bool {
+	_, ok := anyType.GetCachedValue().(*evmtypes.ExtensionOptionsEthereumTx)
+	return ok
+}
 
 // newMonoEVMAnteHandler creates the sdk.AnteHandler implementation for the EVM transactions.
 func newMonoEVMAnteHandler(ctx sdk.Context, options baseevmante.HandlerOptions) sdk.AnteHandler {
 	evmParams := options.EvmKeeper.GetParams(ctx)
 	feemarketParams := options.FeeMarketKeeper.GetParams(ctx)
 	decorators := []sdk.AnteDecorator{
+		ante.NewExtensionOptionsDecorator(isEthereumTxExtensionOption),
 		evmante.NewEVMMonoDecorator(
 			options.AccountKeeper,
 			options.FeeMarketKeeper,


### PR DESCRIPTION
# fix: validate extension options in EVM ante handler

## Motivation 💡

The router in `app/ante/ante.go` only inspects `opts[0]` to choose between the EVM and Cosmos handlers. The Cosmos chain runs `ante.NewExtensionOptionsDecorator`, but the EVM chain (`newMonoEVMAnteHandler`) had no equivalent, so any extension options at `opts[1+]` reached the EVM handler without validation. A crafted tx with a valid `ExtensionOptionsEthereumTx` at `opts[0]` followed by arbitrary extension options would be accepted, potentially smuggling unexpected data past the ante boundary.

## Changes 🛠

- Added `ante.NewExtensionOptionsDecorator` as the first decorator in `newMonoEVMAnteHandler` so every extension option on an EVM-routed tx is validated, not just `opts[0]`.
- Introduced `isEthereumTxExtensionOption` to whitelist only `*evmtypes.ExtensionOptionsEthereumTx`, any other extension option type causes the tx to be rejected.

## Considerations 🤔

- The whitelist is intentionally narrow: only `ExtensionOptionsEthereumTx` is accepted on the EVM path. Any other extension option type (known or unknown) appended to an EVM tx will be rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced transaction processing pipeline for Ethereum extension options in the ante handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->