### PR TITLE
feat: block MsgCreateValidator post-genesis in PoA ante decorator

### DIFF
--- a/app/ante/cosmos_handler.go
+++ b/app/ante/cosmos_handler.go
@@ -29,6 +29,7 @@ func newCosmosAnteHandler(ctx sdk.Context, options baseevmante.HandlerOptions) s
 			sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
 			sdk.MsgTypeURL(&stakingtypes.MsgCancelUnbondingDelegation{}),
 			sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
+			sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}),
 			sdk.MsgTypeURL(&sdkvesting.MsgCreateVestingAccount{}),
 			sdk.MsgTypeURL(&evmtypes.MsgEthereumTx{}),
 		),

--- a/x/poa/ante/poa.go
+++ b/x/poa/ante/poa.go
@@ -7,20 +7,30 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
+var ErrTxTypeNotAllowed = errors.New("tx type not allowed")
+
 type PoaDecorator struct{}
 
 func NewPoaDecorator() PoaDecorator {
 	return PoaDecorator{}
 }
 
+var disallowedMsgs = map[string]struct{}{
+	sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}):                {},
+	sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}):           {},
+	sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}):                  {},
+	sdk.MsgTypeURL(&stakingtypes.MsgCancelUnbondingDelegation{}): {},
+	sdk.MsgTypeURL(&stakingtypes.MsgCreateValidator{}):           {},
+}
+
 func (cbd PoaDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	// loop through all the messages and check if the message type is allowed
+	// Allow genutil gentxs at genesis (block height 0) to bootstrap the initial validator set.
+	if ctx.BlockHeight() == 0 {
+		return next(ctx, tx, simulate)
+	}
 	for _, msg := range tx.GetMsgs() {
-		if sdk.MsgTypeURL(msg) == sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}) ||
-			sdk.MsgTypeURL(msg) == sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}) ||
-			sdk.MsgTypeURL(msg) == sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}) ||
-			sdk.MsgTypeURL(msg) == sdk.MsgTypeURL(&stakingtypes.MsgCancelUnbondingDelegation{}) {
-			return ctx, errors.New("tx type not allowed")
+		if _, blocked := disallowedMsgs[sdk.MsgTypeURL(msg)]; blocked {
+			return ctx, ErrTxTypeNotAllowed
 		}
 	}
 

--- a/x/poa/ante/poa_test.go
+++ b/x/poa/ante/poa_test.go
@@ -1,7 +1,6 @@
 package ante
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -32,44 +31,71 @@ func setupPoaDecorator(t *testing.T) (
 func TestPoaDecorator_AnteHandle(t *testing.T) {
 	tt := []struct {
 		name          string
+		blockHeight   int64
 		msgs          []sdk.Msg
 		expectedError error
 	}{
 		{
-			name: "should return error - tx not allowed",
-			msgs: []sdk.Msg{
-				&stakingtypes.MsgUndelegate{},
-				&stakingtypes.MsgBeginRedelegate{},
-				&stakingtypes.MsgDelegate{},
-				&stakingtypes.MsgCancelUnbondingDelegation{},
-			},
-			expectedError: errors.New("tx type not allowed"),
+			name:          "should return error - rejects MsgUndelegate post-genesis",
+			blockHeight:   1,
+			msgs:          []sdk.Msg{&stakingtypes.MsgUndelegate{}},
+			expectedError: ErrTxTypeNotAllowed,
 		},
 		{
-			name: "should not return error",
-			msgs: []sdk.Msg{
-				&stakingtypes.MsgEditValidator{},
-			},
+			name:          "should return error - rejects MsgBeginRedelegate post-genesis",
+			blockHeight:   1,
+			msgs:          []sdk.Msg{&stakingtypes.MsgBeginRedelegate{}},
+			expectedError: ErrTxTypeNotAllowed,
+		},
+		{
+			name:          "should return error - rejects MsgDelegate post-genesis",
+			blockHeight:   1,
+			msgs:          []sdk.Msg{&stakingtypes.MsgDelegate{}},
+			expectedError: ErrTxTypeNotAllowed,
+		},
+		{
+			name:          "should return error - rejects MsgCancelUnbondingDelegation post-genesis",
+			blockHeight:   1,
+			msgs:          []sdk.Msg{&stakingtypes.MsgCancelUnbondingDelegation{}},
+			expectedError: ErrTxTypeNotAllowed,
+		},
+		{
+			name:          "should return error - rejects MsgCreateValidator post-genesis",
+			blockHeight:   1,
+			msgs:          []sdk.Msg{&stakingtypes.MsgCreateValidator{}},
+			expectedError: ErrTxTypeNotAllowed,
+		},
+		{
+			name:        "pass - allows MsgEditValidator post-genesis",
+			blockHeight: 1,
+			msgs:        []sdk.Msg{&stakingtypes.MsgEditValidator{}},
+		},
+		{
+			name:        "pass - allows MsgCreateValidator at genesis",
+			blockHeight: 0,
+			msgs:        []sdk.Msg{&stakingtypes.MsgCreateValidator{}},
 		},
 	}
 
 	for _, tc := range tt {
-		pd, ctx := setupPoaDecorator(t)
+		t.Run(tc.name, func(t *testing.T) {
+			pd, ctx := setupPoaDecorator(t)
+			ctx = ctx.WithBlockHeight(tc.blockHeight)
 
-		ctrl := gomock.NewController(t)
-		txMock := testutil.NewMockTx(ctrl)
-		txMock.EXPECT().GetMsgs().Return(tc.msgs).AnyTimes()
+			ctrl := gomock.NewController(t)
+			txMock := testutil.NewMockTx(ctrl)
+			txMock.EXPECT().GetMsgs().Return(tc.msgs).AnyTimes()
 
-		mockNext := func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
-			return ctx, nil
-		}
+			mockNext := func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+				return ctx, nil
+			}
 
-		_, err := pd.AnteHandle(ctx, txMock, false, mockNext)
-		if tc.expectedError != nil {
-			require.Error(t, err)
-			require.Equal(t, tc.expectedError, err)
-		} else {
-			require.NoError(t, err)
-		}
+			_, err := pd.AnteHandle(ctx, txMock, false, mockNext)
+			if tc.expectedError != nil {
+				require.ErrorIs(t, err, tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# feat: block MsgCreateValidator post-genesis in PoA ante decorator

## Motivation 💡

In a PoA chain the validator set is closed: validators are added exclusively through `x/poa`'s `ExecuteAddValidator`, which is the only path that mints bond-denomination tokens (and self-delegates them immediately). Because no bond-denom should ever sit on a user account, `MsgCreateValidator` is unsatisfiable in practice today.

That protection is a chain-wide invariant, not an ante-level check, and it is implicit. Any future regression that leaks bond-denom into a user-controlled account (mint path change, IBC misconfig, buggy upgrade handler, airdrop mistake) would immediately allow unauthorized validator registration with no backstop, directly corrupting the closed PoA validator set.

This PR adds a cheap defense-in-depth: reject `MsgCreateValidator` at the ante stage post-genesis, with a height-0 carve-out so `genutil` gentxs still bootstrap the initial validator set.

## Changes 🛠

- `x/poa/ante/poa.go`: added `MsgCreateValidator` to the disallowed message set and introduced a `BlockHeight() == 0` carve-out so genesis gentxs continue to work.
- `x/poa/ante/poa.go`: replaced the inline `||` chain with a `disallowedMsgs` map and lifted the error to a `ErrTxTypeNotAllowed` sentinel so callers and tests can match it with `errors.Is`.
- `app/ante/cosmos_handler.go`: added `MsgCreateValidator` to `AuthzLimiterDecorator` so it cannot be smuggled through `authz.MsgExec`.
- `x/poa/ante/poa_test.go`: split the single aggregated case into one subtest per blocked message (including the new `MsgCreateValidator` case), added a positive case for `MsgCreateValidator` at `blockHeight: 0` to lock in the gentx carve-out, kept the `MsgEditValidator` allow case to document that editing validator metadata is intentionally not gated, and switched assertions to `require.ErrorIs` against the sentinel.

## Considerations 🤔

- `MsgEditValidator` is intentionally left unblocked. Validators are responsible for their own metadata (description, commission within module-enforced bounds), and gating it behind PoA authority would add operational overhead with no real security benefit.
- This is defense-in-depth, not the primary protection. The real invariant (bond-denom can only be minted by `x/poa`) still lives in the mint path, reviewers should not treat this ante check as a license to relax that invariant.
- Each disallowed msg type needs its own test case because the loop returns on the first match, so a single combined case would only ever exercise the first msg in the slice. The split is intentional coverage, not redundancy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validator creation can now be executed through authorization mechanisms, expanding permissible transaction types.

* **Bug Fixes**
  * Transaction validation at genesis block now properly allows all message types without restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->