### PR TITLE
feat: add v11 upgrade handler disabling ICA host

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -6,6 +6,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	v10 "github.com/xrplevm/node/v10/app/upgrades/v10"
+	v11 "github.com/xrplevm/node/v10/app/upgrades/v11"
 	v9 "github.com/xrplevm/node/v10/app/upgrades/v9"
 
 	v5 "github.com/xrplevm/node/v10/app/upgrades/v5"
@@ -61,6 +62,14 @@ func (app *App) setupUpgradeHandlers() {
 			app.mm,
 			app.configurator,
 			app.EvmKeeper,
+		),
+	)
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v11.UpgradeName,
+		v11.CreateUpgradeHandler(
+			app.mm,
+			app.configurator,
+			app.ICAHostKeeper,
 		),
 	)
 

--- a/app/upgrades/v11/constants.go
+++ b/app/upgrades/v11/constants.go
@@ -1,0 +1,5 @@
+package v11
+
+const (
+	UpgradeName = "v11.0.0"
+)

--- a/app/upgrades/v11/keepers.go
+++ b/app/upgrades/v11/keepers.go
@@ -1,0 +1,12 @@
+package v11
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	icahosttypes "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/host/types"
+)
+
+// ICAHostKeeper is the narrow interface required by the v11 upgrade
+// handler. It matches a subset of icahostkeeper.Keeper.
+type ICAHostKeeper interface {
+	SetParams(ctx sdk.Context, params icahosttypes.Params)
+}

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -1,0 +1,33 @@
+package v11
+
+import (
+	"context"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	icahosttypes "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/host/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	icaHostKeeper ICAHostKeeper,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(c)
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+		logger.Info("Running v11 upgrade handler...")
+
+		// Run migrations first so no module migration can restore ICA host defaults.
+		vm, err := mm.RunMigrations(ctx, configurator, vm)
+		if err != nil {
+			return nil, err
+		}
+
+		logger.Info("Disabling ICA host module...")
+		icaHostKeeper.SetParams(ctx, icahosttypes.NewParams(false, nil))
+		logger.Info("Finished v11 upgrade handler")
+		return vm, nil
+	}
+}


### PR DESCRIPTION
# feat: add v11 upgrade handler disabling ICA host

## Motivation 💡

The v11 chain upgrade needs to disable the ICA (Interchain Accounts) host module so the chain stops accepting incoming ICA messages from counterparty chains. This requires an upgrade handler that flips the host params at the upgrade height.

## Changes 🛠

- Added a `v11` upgrade package (`UpgradeName = "v11.0.0"`) with an upgrade handler that sets ICA host params to disabled (`HostEnabled = false`, no allow list)
- Defined a narrow `ICAHostKeeper` interface in the v11 package, matching the subset of `icahostkeeper.Keeper` actually needed by the handler
- Wired the v11 handler into `app/upgrades.go` `setupUpgradeHandlers`, passing `app.ICAHostKeeper`
- Ran module migrations before applying the params change so no later module migration can restore ICA host defaults

## Considerations 🤔

- After v11, ICA host functionality is off, incoming ICA packets from other chains will be rejected. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added v11 upgrade infrastructure to support the network upgrade to version 11.0.0. The upgrade handler executes module migrations and applies configuration changes to disable the IBC interchain-accounts host module, ensuring proper state transitions during the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->