### PR TITLE
test: cover ante routing and upgrade handlers v5-v10

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -36,7 +36,8 @@ exclude:
   paths:
     - cmd
     - docs
-    - app
+    - ^app$
+    - ^app/upgrades/
     - tools
     - tests
     - \.pb\.go$

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -36,8 +36,7 @@ exclude:
   paths:
     - cmd
     - docs
-    - ^app$
-    - ^app/upgrades/
+    - ^app/app\.go$
     - tools
     - tests
     - \.pb\.go$

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ lint-fix:
 ###                                Testing                                  ###
 ###############################################################################
 EXCLUDED_POA_PACKAGES=$(shell go list ./x/poa/... | grep -v /x/poa/testutil | grep -v /x/poa/client | grep -v /x/poa/simulation | grep -v /x/poa/types)
-EXCLUDED_UNIT_PACKAGES=$(shell go list ./... | grep -v tests | grep -v testutil | grep -v tools | grep -v '/app$$' | grep -v /app/upgrades | grep -v docs | grep -v cmd | grep -v /x/poa/testutil | grep -v /x/poa/client | grep -v /x/poa/simulation | grep -v /x/poa/types)
+EXCLUDED_UNIT_PACKAGES=$(shell go list ./... | grep -v tests | grep -v testutil | grep -v tools | grep -v '/app$$' | grep -v docs | grep -v cmd | grep -v /x/poa/testutil | grep -v /x/poa/client | grep -v /x/poa/simulation | grep -v /x/poa/types)
 
 mocks:
 	@echo "--> Installing mockgen"

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ lint-fix:
 ###                                Testing                                  ###
 ###############################################################################
 EXCLUDED_POA_PACKAGES=$(shell go list ./x/poa/... | grep -v /x/poa/testutil | grep -v /x/poa/client | grep -v /x/poa/simulation | grep -v /x/poa/types)
-EXCLUDED_UNIT_PACKAGES=$(shell go list ./... | grep -v tests | grep -v testutil | grep -v tools | grep -v app | grep -v docs | grep -v cmd | grep -v /x/poa/testutil | grep -v /x/poa/client | grep -v /x/poa/simulation | grep -v /x/poa/types)
+EXCLUDED_UNIT_PACKAGES=$(shell go list ./... | grep -v tests | grep -v testutil | grep -v tools | grep -v '/app$$' | grep -v /app/upgrades | grep -v docs | grep -v cmd | grep -v /x/poa/testutil | grep -v /x/poa/client | grep -v /x/poa/simulation | grep -v /x/poa/types)
 
 mocks:
 	@echo "--> Installing mockgen"

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -5,6 +5,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -28,38 +29,32 @@ func newAnteHandler(
 	return func(
 		ctx sdk.Context, tx sdk.Tx, sim bool,
 	) (newCtx sdk.Context, err error) {
-		var anteHandler sdk.AnteHandler
-
-		txWithExtensions, ok := tx.(ante.HasExtensionOptionsTx)
-		if ok {
-			opts := txWithExtensions.GetExtensionOptions()
-			if len(opts) > 0 {
-				switch typeURL := opts[0].GetTypeUrl(); typeURL {
-				case "/cosmos.evm.vm.v1.ExtensionOptionsEthereumTx":
-					// handle as *evmtypes.MsgEthereumTx
-					anteHandler = evmHandler(ctx, options)
-				case "/cosmos.evm.ante.v1.ExtensionOptionDynamicFeeTx":
-					// cosmos-sdk tx with dynamic fee extension
-					anteHandler = cosmosHandler(ctx, options)
-				default:
-					return ctx, errorsmod.Wrapf(
-						errortypes.ErrUnknownExtensionOptions,
-						"rejecting tx with unsupported extension option: %s", typeURL,
-					)
-				}
-
-				return anteHandler(ctx, tx, sim)
-			}
+		if tx == nil {
+			return ctx, errorsmod.Wrap(errortypes.ErrUnknownRequest, "tx is nil")
 		}
 
-		// handle as totally normal Cosmos SDK tx
-		switch tx.(type) {
-		case sdk.Tx:
+		var opts []*codectypes.Any
+		if txExt, ok := tx.(ante.HasExtensionOptionsTx); ok {
+			opts = txExt.GetExtensionOptions()
+		}
+		if len(opts) == 0 {
+			return cosmosHandler(ctx, options)(ctx, tx, sim)
+		}
+
+		var anteHandler sdk.AnteHandler
+		switch typeURL := opts[0].GetTypeUrl(); typeURL {
+		case "/cosmos.evm.vm.v1.ExtensionOptionsEthereumTx":
+			// handle as *evmtypes.MsgEthereumTx
+			anteHandler = evmHandler(ctx, options)
+		case "/cosmos.evm.ante.v1.ExtensionOptionDynamicFeeTx":
+			// cosmos-sdk tx with dynamic fee extension
 			anteHandler = cosmosHandler(ctx, options)
 		default:
-			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid transaction type: %T", tx)
+			return ctx, errorsmod.Wrapf(
+				errortypes.ErrUnknownExtensionOptions,
+				"rejecting tx with unsupported extension option: %s", typeURL,
+			)
 		}
-
 		return anteHandler(ctx, tx, sim)
 	}
 }

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -10,11 +10,21 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 )
 
+type anteHandlerFactory func(sdk.Context, baseevmante.HandlerOptions) sdk.AnteHandler
+
 // NewAnteHandler returns an ante handler responsible for attempting to route an
 // Ethereum or SDK transaction to an internal ante handler for performing
 // transaction-level processing (e.g. fee payment, signature verification) before
 // being passed onto it's respective handler.
 func NewAnteHandler(options baseevmante.HandlerOptions) sdk.AnteHandler {
+	return newAnteHandler(options, newCosmosAnteHandler, newMonoEVMAnteHandler)
+}
+
+func newAnteHandler(
+	options baseevmante.HandlerOptions,
+	cosmosHandler anteHandlerFactory,
+	evmHandler anteHandlerFactory,
+) sdk.AnteHandler {
 	return func(
 		ctx sdk.Context, tx sdk.Tx, sim bool,
 	) (newCtx sdk.Context, err error) {
@@ -27,10 +37,10 @@ func NewAnteHandler(options baseevmante.HandlerOptions) sdk.AnteHandler {
 				switch typeURL := opts[0].GetTypeUrl(); typeURL {
 				case "/cosmos.evm.vm.v1.ExtensionOptionsEthereumTx":
 					// handle as *evmtypes.MsgEthereumTx
-					anteHandler = newMonoEVMAnteHandler(ctx, options)
+					anteHandler = evmHandler(ctx, options)
 				case "/cosmos.evm.ante.v1.ExtensionOptionDynamicFeeTx":
 					// cosmos-sdk tx with dynamic fee extension
-					anteHandler = newCosmosAnteHandler(ctx, options)
+					anteHandler = cosmosHandler(ctx, options)
 				default:
 					return ctx, errorsmod.Wrapf(
 						errortypes.ErrUnknownExtensionOptions,
@@ -45,7 +55,7 @@ func NewAnteHandler(options baseevmante.HandlerOptions) sdk.AnteHandler {
 		// handle as totally normal Cosmos SDK tx
 		switch tx.(type) {
 		case sdk.Tx:
-			anteHandler = newCosmosAnteHandler(ctx, options)
+			anteHandler = cosmosHandler(ctx, options)
 		default:
 			return ctx, errorsmod.Wrapf(errortypes.ErrUnknownRequest, "invalid transaction type: %T", tx)
 		}

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -1,0 +1,121 @@
+package ante
+
+import (
+	"errors"
+	"testing"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	baseevmante "github.com/cosmos/evm/ante"
+	antetypes "github.com/cosmos/evm/ante/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+)
+
+// Sentinel errors returned by the stub ante handlers to signal which branch
+// the router selected, so tests can assert routing without a real ante chain.
+var (
+	errRoutedToCosmosAnte = errors.New("routed to cosmos ante")
+	errRoutedToEVMAnte    = errors.New("routed to evm ante")
+)
+
+type routingTx struct {
+	msgs             []sdk.Msg
+	extensionOptions []*codectypes.Any
+}
+
+var _ sdk.Tx = routingTx{}
+var _ authante.HasExtensionOptionsTx = routingTx{}
+
+func (tx routingTx) GetMsgs() []sdk.Msg {
+	return tx.msgs
+}
+
+func (tx routingTx) GetMsgsV2() ([]protov2.Message, error) {
+	return nil, nil
+}
+
+func (tx routingTx) GetExtensionOptions() []*codectypes.Any {
+	return tx.extensionOptions
+}
+
+func (tx routingTx) GetNonCriticalExtensionOptions() []*codectypes.Any {
+	return nil
+}
+
+func stubAnteHandlerFactory(routeErr error) anteHandlerFactory {
+	return func(sdk.Context, baseevmante.HandlerOptions) sdk.AnteHandler {
+		return func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+			return ctx, routeErr
+		}
+	}
+}
+
+func TestNewAnteHandlerRouting(t *testing.T) {
+	ethExtension, err := codectypes.NewAnyWithValue(&evmtypes.ExtensionOptionsEthereumTx{})
+	require.NoError(t, err)
+	dynamicFeeExtension, err := codectypes.NewAnyWithValue(&antetypes.ExtensionOptionDynamicFeeTx{})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name            string
+		tx              sdk.Tx
+		wantErr         error
+		wantErrContains string
+	}{
+		{
+			name: "ethereum extension routes to evm ante",
+			tx: routingTx{
+				msgs:             []sdk.Msg{&evmtypes.MsgEthereumTx{}},
+				extensionOptions: []*codectypes.Any{ethExtension},
+			},
+			wantErr: errRoutedToEVMAnte,
+		},
+		{
+			name:    "dynamic fee extension routes to cosmos ante",
+			tx:      routingTx{extensionOptions: []*codectypes.Any{dynamicFeeExtension}},
+			wantErr: errRoutedToCosmosAnte,
+		},
+		{
+			name:    "no extension routes to cosmos ante",
+			tx:      routingTx{},
+			wantErr: errRoutedToCosmosAnte,
+		},
+		{
+			name: "unknown extension is rejected",
+			tx: routingTx{
+				extensionOptions: []*codectypes.Any{{
+					TypeUrl: "/cosmos.evm.test.v1.UnknownExtensionOption",
+				}},
+			},
+			wantErr:         errortypes.ErrUnknownExtensionOptions,
+			wantErrContains: "rejecting tx with unsupported extension option: /cosmos.evm.test.v1.UnknownExtensionOption",
+		},
+		{
+			name:            "nil tx is rejected",
+			tx:              nil,
+			wantErr:         errortypes.ErrUnknownRequest,
+			wantErrContains: "invalid transaction type: <nil>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newAnteHandler(
+				baseevmante.HandlerOptions{},
+				stubAnteHandlerFactory(errRoutedToCosmosAnte),
+				stubAnteHandlerFactory(errRoutedToEVMAnte),
+			)
+
+			_, err := handler(sdk.Context{}, tc.tx, false)
+
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErrContains != "" {
+				require.ErrorContains(t, err, tc.wantErrContains)
+			}
+		})
+	}
+}

--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -27,8 +27,10 @@ type routingTx struct {
 	extensionOptions []*codectypes.Any
 }
 
-var _ sdk.Tx = routingTx{}
-var _ authante.HasExtensionOptionsTx = routingTx{}
+var (
+	_ sdk.Tx                         = routingTx{}
+	_ authante.HasExtensionOptionsTx = routingTx{}
+)
 
 func (tx routingTx) GetMsgs() []sdk.Msg {
 	return tx.msgs
@@ -98,7 +100,7 @@ func TestNewAnteHandlerRouting(t *testing.T) {
 			name:            "nil tx is rejected",
 			tx:              nil,
 			wantErr:         errortypes.ErrUnknownRequest,
-			wantErrContains: "invalid transaction type: <nil>",
+			wantErrContains: "tx is nil",
 		},
 	}
 

--- a/app/upgrades/v10/upgrades_test.go
+++ b/app/upgrades/v10/upgrades_test.go
@@ -1,0 +1,53 @@
+package v10
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+var _ EvmKeeper = (*mockEvmKeeper)(nil)
+
+type mockEvmKeeper struct {
+	initErr    error
+	initCalled bool
+}
+
+func (m *mockEvmKeeper) GetParams(sdk.Context) evmtypes.Params        { return evmtypes.Params{} }
+func (m *mockEvmKeeper) SetParams(sdk.Context, evmtypes.Params) error { return nil }
+func (m *mockEvmKeeper) SetCodeHash(sdk.Context, []byte, []byte)      {}
+func (m *mockEvmKeeper) InitEvmCoinInfo(sdk.Context) error {
+	m.initCalled = true
+	return m.initErr
+}
+
+func TestCreateUpgradeHandlerInitializesEvmCoinInfo(t *testing.T) {
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	moduleManager := module.NewManager()
+	configurator := module.NewConfigurator(
+		codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
+		grpc.NewServer(),
+		grpc.NewServer(),
+	)
+	keeper := &mockEvmKeeper{}
+	versions := module.VersionMap{"bank": 1}
+
+	updatedVersions, err := CreateUpgradeHandler(moduleManager, configurator, keeper)(
+		ctx,
+		upgradetypes.Plan{Name: UpgradeName},
+		versions,
+	)
+
+	require.NoError(t, err)
+	require.True(t, keeper.initCalled)
+	require.Empty(t, updatedVersions)
+}

--- a/app/upgrades/v5/upgrades_test.go
+++ b/app/upgrades/v5/upgrades_test.go
@@ -1,0 +1,35 @@
+package v5
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestCreateUpgradeHandlerCompletes(t *testing.T) {
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	moduleManager := module.NewManager()
+	configurator := module.NewConfigurator(
+		codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
+		grpc.NewServer(),
+		grpc.NewServer(),
+	)
+	versions := module.VersionMap{"bank": 1}
+
+	updatedVersions, err := CreateUpgradeHandler(moduleManager, configurator)(
+		ctx,
+		upgradetypes.Plan{Name: UpgradeName},
+		versions,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, updatedVersions)
+}

--- a/app/upgrades/v6/upgrades_test.go
+++ b/app/upgrades/v6/upgrades_test.go
@@ -1,0 +1,35 @@
+package v6
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestCreateUpgradeHandlerCompletes(t *testing.T) {
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	moduleManager := module.NewManager()
+	configurator := module.NewConfigurator(
+		codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
+		grpc.NewServer(),
+		grpc.NewServer(),
+	)
+	versions := module.VersionMap{"bank": 1}
+
+	updatedVersions, err := CreateUpgradeHandler(moduleManager, configurator)(
+		ctx,
+		upgradetypes.Plan{Name: UpgradeName},
+		versions,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, updatedVersions)
+}

--- a/app/upgrades/v7/upgrades_test.go
+++ b/app/upgrades/v7/upgrades_test.go
@@ -1,0 +1,35 @@
+package v7
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestCreateUpgradeHandlerCompletes(t *testing.T) {
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	moduleManager := module.NewManager()
+	configurator := module.NewConfigurator(
+		codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
+		grpc.NewServer(),
+		grpc.NewServer(),
+	)
+	versions := module.VersionMap{"bank": 1}
+
+	updatedVersions, err := CreateUpgradeHandler(moduleManager, configurator)(
+		ctx,
+		upgradetypes.Plan{Name: UpgradeName},
+		versions,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, updatedVersions)
+}

--- a/app/upgrades/v8/upgrades_test.go
+++ b/app/upgrades/v8/upgrades_test.go
@@ -1,0 +1,35 @@
+package v8
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestCreateUpgradeHandlerCompletes(t *testing.T) {
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	moduleManager := module.NewManager()
+	configurator := module.NewConfigurator(
+		codec.NewProtoCodec(codectypes.NewInterfaceRegistry()),
+		grpc.NewServer(),
+		grpc.NewServer(),
+	)
+	versions := module.VersionMap{"bank": 1}
+
+	updatedVersions, err := CreateUpgradeHandler(moduleManager, configurator)(
+		ctx,
+		upgradetypes.Plan{Name: UpgradeName},
+		versions,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, updatedVersions)
+}

--- a/app/upgrades/v9/upgrades_test.go
+++ b/app/upgrades/v9/upgrades_test.go
@@ -1,0 +1,244 @@
+package v9
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	auth "github.com/cosmos/cosmos-sdk/x/auth"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	erc20types "github.com/cosmos/evm/x/erc20/types"
+	evmtypes "github.com/cosmos/evm/x/vm/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	legacyevmtypes "github.com/xrplevm/node/v10/types/legacy/ethermint/evm"
+	legacytypes "github.com/xrplevm/node/v10/types/legacy/ethermint/types"
+	"google.golang.org/grpc"
+)
+
+var (
+	_ ERC20Keeper = (*mockERC20Keeper)(nil)
+	_ EvmKeeper   = (*mockEvmKeeper)(nil)
+)
+
+type mockERC20Keeper struct {
+	dynamicPrecompiles []common.Address
+	nativePrecompiles  []common.Address
+}
+
+func (m *mockERC20Keeper) SetDynamicPrecompile(_ sdk.Context, precompile common.Address) {
+	m.dynamicPrecompiles = append(m.dynamicPrecompiles, precompile)
+}
+
+func (m *mockERC20Keeper) SetNativePrecompile(_ sdk.Context, precompile common.Address) {
+	m.nativePrecompiles = append(m.nativePrecompiles, precompile)
+}
+
+type mockEvmKeeper struct {
+	params       evmtypes.Params
+	setParams    bool
+	codeHashes   map[common.Address]common.Hash
+	setParamsErr error
+}
+
+func (m *mockEvmKeeper) GetParams(sdk.Context) evmtypes.Params { return m.params }
+func (m *mockEvmKeeper) SetParams(_ sdk.Context, params evmtypes.Params) error {
+	m.setParams = true
+	m.params = params
+	return m.setParamsErr
+}
+
+func (m *mockEvmKeeper) SetCodeHash(_ sdk.Context, addrBytes, hashBytes []byte) {
+	if m.codeHashes == nil {
+		m.codeHashes = make(map[common.Address]common.Hash)
+	}
+	m.codeHashes[common.BytesToAddress(addrBytes)] = common.BytesToHash(hashBytes)
+}
+
+func TestCreateUpgradeHandlerMigratesLegacyState(t *testing.T) {
+	const dynamicPrecompile = "0x0000000000000000000000000000000000000001"
+
+	appCodec := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	configurator := module.NewConfigurator(appCodec, grpc.NewServer(), grpc.NewServer())
+	moduleManager := module.NewManager()
+	versions := module.VersionMap{"bank": 1}
+
+	ctx, storeKeys := testContext(t, authtypes.StoreKey, erc20types.StoreKey, evmtypes.StoreKey)
+	setLegacyEvmParams(ctx, storeKeys, appCodec, legacyevmtypes.Params{
+		EvmDenom: "axrp",
+	})
+	ctx.KVStore(storeKeys[erc20types.StoreKey]).Set([]byte("DynamicPrecompiles"), []byte(dynamicPrecompile))
+
+	accountKeeper := testAccountKeeper(storeKeys[authtypes.StoreKey])
+	evmKeeper := &mockEvmKeeper{}
+	erc20Keeper := &mockERC20Keeper{}
+
+	updatedVersions, err := CreateUpgradeHandler(
+		moduleManager,
+		configurator,
+		storeKeys,
+		appCodec,
+		accountKeeper,
+		evmKeeper,
+		erc20Keeper,
+	)(
+		ctx,
+		upgradetypes.Plan{Name: UpgradeName},
+		versions,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, updatedVersions)
+	require.Equal(t, []common.Address{common.HexToAddress(dynamicPrecompile)}, erc20Keeper.dynamicPrecompiles)
+	require.True(t, evmKeeper.setParams)
+}
+
+func TestMigrateEvmModuleMigratesLegacyParams(t *testing.T) {
+	const (
+		createAllowedAddress  = "0x0000000000000000000000000000000000000001"
+		callRestrictedAddress = "0x0000000000000000000000000000000000000002"
+		staticPrecompile      = "0x0000000000000000000000000000000000000003"
+	)
+	ctx, storeKeys := testContext(t, evmtypes.StoreKey)
+	appCodec := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	legacyParams := legacyevmtypes.Params{
+		EvmDenom:    "axrp",
+		ExtraEIPs:   []string{"ethereum_3855", "ethereum_3860"},
+		EVMChannels: []string{"channel-0"},
+		AccessControl: legacyevmtypes.AccessControl{
+			Create: legacyevmtypes.AccessControlType{
+				AccessType:        legacyevmtypes.AccessTypePermissioned,
+				AccessControlList: []string{createAllowedAddress},
+			},
+			Call: legacyevmtypes.AccessControlType{
+				AccessType:        legacyevmtypes.AccessTypeRestricted,
+				AccessControlList: []string{callRestrictedAddress},
+			},
+		},
+		ActiveStaticPrecompiles: []string{staticPrecompile},
+	}
+	expectedParams := evmtypes.Params{
+		EvmDenom:    "axrp",
+		ExtraEIPs:   []int64{3855, 3860},
+		EVMChannels: []string{"channel-0"},
+		AccessControl: evmtypes.AccessControl{
+			Create: evmtypes.AccessControlType{
+				AccessType:        evmtypes.AccessTypePermissioned,
+				AccessControlList: []string{createAllowedAddress},
+			},
+			Call: evmtypes.AccessControlType{
+				AccessType:        evmtypes.AccessTypeRestricted,
+				AccessControlList: []string{callRestrictedAddress},
+			},
+		},
+		ActiveStaticPrecompiles: []string{staticPrecompile},
+	}
+	setLegacyEvmParams(ctx, storeKeys, appCodec, legacyParams)
+	keeper := &mockEvmKeeper{}
+
+	err := MigrateEvmModule(ctx, storeKeys, appCodec, keeper)
+
+	require.NoError(t, err)
+	require.True(t, keeper.setParams)
+	require.Equal(t, expectedParams, keeper.params)
+}
+
+func TestMigrateErc20ModuleMigratesAndDeletesLegacyPrecompiles(t *testing.T) {
+	const (
+		dynamicPrecompile1 = "0x0000000000000000000000000000000000000001"
+		dynamicPrecompile2 = "0x0000000000000000000000000000000000000002"
+		nativePrecompile   = "0x0000000000000000000000000000000000000003"
+	)
+	dynamicPrecompiles := []byte(dynamicPrecompile1 + dynamicPrecompile2)
+	nativePrecompiles := []byte(nativePrecompile)
+
+	ctx, storeKeys := testContext(t, erc20types.StoreKey)
+	store := ctx.KVStore(storeKeys[erc20types.StoreKey])
+
+	store.Set([]byte("DynamicPrecompiles"), dynamicPrecompiles)
+	store.Set([]byte("NativePrecompiles"), nativePrecompiles)
+
+	keeper := &mockERC20Keeper{}
+
+	MigrateErc20Module(ctx, storeKeys, keeper)
+
+	require.Equal(t, []common.Address{
+		common.HexToAddress(dynamicPrecompile1),
+		common.HexToAddress(dynamicPrecompile2),
+	}, keeper.dynamicPrecompiles)
+
+	require.Equal(t, []common.Address{common.HexToAddress(nativePrecompile)}, keeper.nativePrecompiles)
+	require.Nil(t, store.Get([]byte("DynamicPrecompiles")))
+	require.Nil(t, store.Get([]byte("NativePrecompiles")))
+}
+
+func TestMigrateEthAccountsToBaseAccountsConvertsContracts(t *testing.T) {
+	ctx, storeKeys := testContext(t, authtypes.StoreKey)
+	accountKeeper := testAccountKeeper(storeKeys[authtypes.StoreKey])
+	contractAddress := sdk.AccAddress(common.HexToAddress("0x0000000000000000000000000000000000000007").Bytes())
+	codeHash := common.HexToHash("0x1234")
+	ethAccount := &legacytypes.EthAccount{
+		BaseAccount: authtypes.NewBaseAccount(contractAddress, nil, 0, 0),
+		CodeHash:    codeHash.Hex(),
+	}
+	accountKeeper.SetAccount(ctx, ethAccount)
+	keeper := &mockEvmKeeper{}
+
+	MigrateEthAccountsToBaseAccounts(ctx, accountKeeper, keeper)
+
+	require.IsType(t, &authtypes.BaseAccount{}, accountKeeper.GetAccount(ctx, contractAddress))
+	require.Equal(t, codeHash, keeper.codeHashes[common.BytesToAddress(contractAddress)])
+}
+
+func testAccountKeeper(key *storetypes.KVStoreKey) authkeeper.AccountKeeper {
+	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{})
+	encCfg.InterfaceRegistry.RegisterImplementations((*sdk.AccountI)(nil), &legacytypes.EthAccount{})
+
+	return authkeeper.NewAccountKeeper(
+		encCfg.Codec,
+		runtime.NewKVStoreService(key),
+		legacytypes.ProtoAccount,
+		nil,
+		authcodec.NewBech32Codec("cosmos"),
+		"cosmos",
+		authtypes.NewModuleAddress("gov").String(),
+	)
+}
+
+func setLegacyEvmParams(
+	ctx sdk.Context,
+	storeKeys map[string]*storetypes.KVStoreKey,
+	appCodec codec.Codec,
+	params legacyevmtypes.Params,
+) {
+	ctx.KVStore(storeKeys[evmtypes.StoreKey]).Set(evmtypes.KeyPrefixParams, appCodec.MustMarshal(&params))
+}
+
+func testContext(t *testing.T, storeKeys ...string) (sdk.Context, map[string]*storetypes.KVStoreKey) {
+	t.Helper()
+
+	db := dbm.NewMemDB()
+	ms := store.NewCommitMultiStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+	keys := make(map[string]*storetypes.KVStoreKey, len(storeKeys))
+	for _, storeKey := range storeKeys {
+		key := storetypes.NewKVStoreKey(storeKey)
+		keys[storeKey] = key
+		ms.MountStoreWithDB(key, storetypes.StoreTypeIAVL, db)
+	}
+	require.NoError(t, ms.LoadLatestVersion())
+
+	return sdk.NewContext(ms, cmtproto.Header{}, false, log.NewNopLogger()), keys
+}


### PR DESCRIPTION
# test: cover ante routing and upgrade handlers v5-v10

## Motivation 💡

The `app/ante` and `app/upgrades` packages were globally excluded from coverage and had no unit tests. `NewAnteHandler` constructed its cosmos and EVM sub-handlers inline, so routing decisions could not be asserted without spinning up the full ante chain, and every upgrade handler shipped untested. This PR brings both packages under coverage tooling and adds focused tests for the routing logic and each upgrade migration from v5 through v10.

## Changes 🛠

- Extracted handler construction in `app/ante/ante.go` into an `anteHandlerFactory` type and a private `newAnteHandler(options, cosmosHandler, evmHandler)`, with the public `NewAnteHandler` wiring in the real `newCosmosAnteHandler` / `newMonoEVMAnteHandler` factories.
- Added `app/ante/ante_test.go` covering routing for `ExtensionOptionsEthereumTx`, `ExtensionOptionDynamicFeeTx`, unknown extension options, nil transactions, and the default Cosmos SDK path, using stub factories that return sentinel errors to identify the selected branch.
- Added unit tests for upgrade handlers v5, v6, v7, v8, v9, and v10 under `app/upgrades/<v>/upgrades_test.go`, asserting migration behavior and store changes for each upgrade.
- Narrowed the `.testcoverage.yml` exclusion from the whole `app` tree to just `^app/app\.go$`, so `app/ante` and all `app/upgrades/*` subpackages are now measured.
- Updated `EXCLUDED_UNIT_PACKAGES` in `Makefile` to anchor the exclusion (`/app$$`) so `make test-unit` runs the new tests in `app/ante` and `app/upgrades`.
