### PR TITLE
fix: include v7-v10 upgrades in store upgrades switch

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -79,8 +79,12 @@ func (app *App) setupUpgradeHandlers() {
 	var storeUpgrades *storetypes.StoreUpgrades
 
 	switch upgradeInfo.Name {
-	case v5.UpgradeName, v6.UpgradeName:
-		// No store upgrades for v5
+	case v5.UpgradeName,
+		v6.UpgradeName,
+		v7.UpgradeName,
+		v8.UpgradeName,
+		v9.UpgradeName,
+		v10.UpgradeName:
 		storeUpgrades = &storetypes.StoreUpgrades{}
 	}
 


### PR DESCRIPTION
# fix: include v7-v10 upgrades in store upgrades switch

## Motivation 💡

The store upgrades switch in `setupUpgradeHandlers` only matched `v5` and `v6`, so reaching the `v7`, `v8`, `v9`, or `v10` upgrade heights would not assign an empty `StoreUpgrades` and the store loader would never be configured for those plans. All registered upgrade handlers should be reflected in the switch.

## Changes 🛠

- Added `v7.UpgradeName`, `v8.UpgradeName`, `v9.UpgradeName`, and `v10.UpgradeName` to the `switch upgradeInfo.Name` block in `app/upgrades.go` so they share the same empty `StoreUpgrades` path as v5/v6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended support for additional upgrade versions in the application upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->