### PR TITLE
ci: add govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,36 @@
+name: Govulncheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    # Weekly scan to catch newly disclosed CVEs in dependencies.
+    # 09:00 UTC Mondays = 10:00 CET (winter) / 11:00 CEST (summer).
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel old runs if there is a new commit in the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
# ci: add govulncheck workflow

## Motivation 💡

We had no automated check for known CVEs in our Go dependencies. Adding `govulncheck` to CI catches newly disclosed vulnerabilities on every PR, on push to `main`, and on a weekly schedule, so issues surface even when no code is changing.

## Changes 🛠

- Added `.github/workflows/govulncheck.yml` running on `push` to `main`, `pull_request`, weekly cron (Mondays 09:00 UTC), and `workflow_dispatch`
- Scoped workflow permissions to `contents: read` (least privilege, no write access needed)
- Run `govulncheck` directly via `actions/setup-go` + `go install` instead of `golang/govulncheck-action`, which fails with a duplicate `Authorization` header on current runners
- Pinned `actions/checkout` and `actions/setup-go` to commit SHAs

## Considerations 🤔

Workflow failing **as expected**. govulncheck reports vulnerabilities pulled in transitively through `cosmos-sdk` / `cosmos-evm`. Cannot be fixed here. Need upstream bump first to keep compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new automated CI workflow that runs vulnerability scanning on pushes to main, on pull requests, weekly (Mondays 09:00 UTC), and via manual dispatch. It uses read-only repository permissions and concurrency control to cancel older runs for the same branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->