### PR TITLE
fix: handle interface registry creation errors

### DIFF
--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"cosmossdk.io/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	legacytypes "github.com/xrplevm/node/v10/types/legacy/ethermint/types"
@@ -39,10 +41,13 @@ func MakeEncodingConfig(evmChainID uint64) sdktestutil.TestEncodingConfig {
 		},
 	}
 
-	interfaceRegistry, _ := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
+	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles:     proto.HybridResolver,
 		SigningOptions: signingOptions,
 	})
+	if err != nil {
+		panic(fmt.Errorf("failed to create interface registry: %w", err))
+	}
 
 	interfaceRegistry.RegisterImplementations((*sdk.Msg)(nil),
 		&poalegacytypes.MsgAddValidator{},


### PR DESCRIPTION
# fix: handle interface registry creation errors

## Motivation 💡

- `types.NewInterfaceRegistryWithOptions` can return an error, but `MakeEncodingConfig` ignored it.

## Changes 🛠

- Panic if an error is returned when creating the interface registry.

## Considerations 🤔

- `MakeEncodingConfig` does not return an error, and the app cannot continue with a failed interface registry, so failing fast is appropriate here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during application initialization to prevent silent failures and provide clearer error reporting when registry creation encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->