### PR TITLE
fix: align cosmossdk core requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.8
 require (
 	cosmossdk.io/api v0.9.2
 	cosmossdk.io/client/v2 v2.0.0-beta.7
-	cosmossdk.io/core v0.12.0
+	cosmossdk.io/core v0.11.3
 	cosmossdk.io/errors v1.0.2
 	cosmossdk.io/log v1.6.1
 	cosmossdk.io/math v1.5.3
@@ -278,8 +278,6 @@ require (
 )
 
 replace (
-	// need this replace when importing cosmos/rosetta pkg
-	cosmossdk.io/core => cosmossdk.io/core v0.11.3
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	// use Cosmos-SDK fork to enable Ledger functionality


### PR DESCRIPTION
# fix: align cosmossdk core requirement

## Motivation 💡

- Remove the silent `cosmossdk.io/core` downgrade where `go.mod` required `v0.12.0` but resolved `v0.11.3` through a replace directive.
- Avoid depending on `cosmossdk.io/core v0.12.0`, which is retracted and incompatible with the Cosmos SDK fork used by this repository.

## Changes 🛠

- Changed the direct `cosmossdk.io/core` requirement from `v0.12.0` to `v0.11.3`.
- Removed the stale `cosmossdk.io/core => cosmossdk.io/core v0.11.3` replace directive and rosetta workaround comment.

## Considerations 🤔

- `go list -m -json -retracted cosmossdk.io/core@v0.12.0` reports that `v0.12.0` was tagged too early and is incompatible with Cosmos SDK `v0.50`.
- `v0.12.0` renames `comet.BlockInfo` to `comet.Info`, which breaks the current `github.com/xrplevm/cosmos-sdk v0.53.6-xrplevm.1` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->