### PR TITLE
fix: pass transfer params subspace to TransferKeeper

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -520,7 +520,7 @@ func New(
 	app.TransferKeeper = transferkeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(keys[ibctransfertypes.StoreKey]),
-		nil,
+		app.GetSubspace(ibctransfertypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
 		app.MsgServiceRouter(),


### PR DESCRIPTION
# fix: pass transfer params subspace to TransferKeeper

## Motivation 💡

- The transfer keeper was initialized with a nil params subspace.

## Changes 🛠

- Pass `app.GetSubspace(ibctransfertypes.ModuleName)` into `transferkeeper.NewKeeper`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Transfer module initialization to ensure module parameters are properly sourced from the configuration subsystem, improving reliability and consistency of inter-blockchain transfer operations across the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->