### PR TITLE
fix: register poa params subspace

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1127,6 +1127,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(slashingtypes.ModuleName)
 	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govv1.ParamKeyTable())
 	paramsKeeper.Subspace(crisistypes.ModuleName)
+	paramsKeeper.Subspace(poatypes.ModuleName)
 
 	keyTable := ibcclienttypes.ParamKeyTable()
 	keyTable.RegisterParamSet(&ibcconnectiontypes.Params{})


### PR DESCRIPTION
# fix: register poa params subspace

## Motivation 💡

- POA module params subspace was not registered in `paramsKeeper`, leaving the module without its expected params storage namespace.

## Changes 🛠
- Register `poatypes.ModuleName` subspace on `paramsKeeper` in `app/app.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PoA module initialization by setting up parameter configuration during keeper setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->