### PR TITLE
fix: remove test grpc service

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -76,7 +76,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
-	testdata_pulsar "github.com/cosmos/cosmos-sdk/testutil/testdata/testpb"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -782,8 +781,6 @@ func New(
 		panic(err)
 	}
 	reflectionv1.RegisterReflectionServiceServer(app.GRPCQueryRouter(), reflectionSvc)
-	// add test gRPC service for testing gRPC queries in isolation
-	testdata_pulsar.RegisterQueryServer(app.GRPCQueryRouter(), testdata_pulsar.QueryImpl{})
 
 	// create the simulation manager and define the order of the modules for deterministic simulations
 	//


### PR DESCRIPTION
# fix: remove test grpc service

## Motivation 💡

- The production app constructor registered `github.com/cosmos/cosmos-sdk/testutil/testdata/testpb` on the live gRPC query router. That package is an SDK test utility and should not be exposed by production nodes.

## Changes 🛠

- Removed the `testdata_pulsar` import from `app/app.go`.
- Removed the `testdata_pulsar.RegisterQueryServer(...)` call from `New()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed test service registration from app initialization, preventing unnecessary test components from being loaded during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->