### PR TITLE
feat: set staking unbonding time to one week in v11 upgrade

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -70,6 +70,7 @@ func (app *App) setupUpgradeHandlers() {
 			app.mm,
 			app.configurator,
 			app.ICAHostKeeper,
+			app.StakingKeeper,
 		),
 	)
 

--- a/app/upgrades/v11/keepers.go
+++ b/app/upgrades/v11/keepers.go
@@ -1,7 +1,10 @@
 package v11
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	icahosttypes "github.com/cosmos/ibc-go/v10/modules/apps/27-interchain-accounts/host/types"
 )
 
@@ -9,4 +12,11 @@ import (
 // handler. It matches a subset of icahostkeeper.Keeper.
 type ICAHostKeeper interface {
 	SetParams(ctx sdk.Context, params icahosttypes.Params)
+}
+
+// StakingKeeper is the narrow interface required by the v11 upgrade
+// handler. It matches a subset of staking.Keeper.
+type StakingKeeper interface {
+	GetParams(ctx context.Context) (params stakingtypes.Params, err error)
+	SetParams(ctx context.Context, params stakingtypes.Params) error
 }

--- a/app/upgrades/v11/upgrades.go
+++ b/app/upgrades/v11/upgrades.go
@@ -2,6 +2,7 @@ package v11
 
 import (
 	"context"
+	"time"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,6 +14,7 @@ func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 	icaHostKeeper ICAHostKeeper,
+	stakingKeeper StakingKeeper,
 ) upgradetypes.UpgradeHandler {
 	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
@@ -22,6 +24,17 @@ func CreateUpgradeHandler(
 		// Run migrations first so no module migration can restore ICA host defaults.
 		vm, err := mm.RunMigrations(ctx, configurator, vm)
 		if err != nil {
+			return nil, err
+		}
+
+		stakingParams, err := stakingKeeper.GetParams(c)
+		if err != nil {
+			return nil, err
+		}
+
+		stakingParams.UnbondingTime = 7 * 24 * time.Hour
+
+		if err := stakingKeeper.SetParams(c, stakingParams); err != nil {
 			return nil, err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1
-	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.6.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7
@@ -218,6 +217,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.21.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/x/poa/keeper/msg_server_remove_validator_test.go
+++ b/x/poa/keeper/msg_server_remove_validator_test.go
@@ -10,10 +10,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/xrplevm/node/v10/x/poa/testutil"
 	"github.com/xrplevm/node/v10/x/poa/types"
+	"go.uber.org/mock/gomock"
 )
 
 func TestMsgServer_RemoveValidator(t *testing.T) {


### PR DESCRIPTION
Increase staking unbonding time to one week in v11 from the current 1 day

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Upgrades**
  * V11 upgrade now automatically configures staking parameters, setting the unbonding period to 7 days during the migration process.
* **Maintenance**
  * Expanded the v11 upgrade handler’s required dependencies to include staking parameter access.
  * Minor test and dependency-list cleanups (mock import path, go.mod ordering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->