### PR TITLE
fix(poa): format staking_tokens as decimal string

### DIFF
--- a/x/poa/keeper/keeper.go
+++ b/x/poa/keeper/keeper.go
@@ -283,7 +283,7 @@ func (k Keeper) ExecuteRemoveValidator(ctx sdk.Context, validatorAddress string)
 			types.EventTypeRemoveValidator,
 			sdk.NewAttribute(types.AttributeValidator, validatorAddress),
 			sdk.NewAttribute(types.AttributeHeight, fmt.Sprintf("%d", ctx.BlockHeight())),
-			sdk.NewAttribute(types.AttributeStakingTokens, fmt.Sprintf("%d", validator.Tokens)),
+			sdk.NewAttribute(types.AttributeStakingTokens, validator.Tokens.String()),
 		),
 	)
 
@@ -313,7 +313,7 @@ func (k Keeper) ExecuteSelfRemoveValidator(ctx sdk.Context, validatorAddress str
 			types.EventTypeSelfRemoveValidator,
 			sdk.NewAttribute(types.AttributeValidator, valAddress.String()),
 			sdk.NewAttribute(types.AttributeHeight, fmt.Sprintf("%d", ctx.BlockHeight())),
-			sdk.NewAttribute(types.AttributeStakingTokens, fmt.Sprintf("%d", validator.Tokens)),
+			sdk.NewAttribute(types.AttributeStakingTokens, validator.Tokens.String()),
 		),
 	)
 


### PR DESCRIPTION
The remove_validator and self_remove_validator events emitted a malformed staking_tokens value because fmt.Sprintf("%d", validator.Tokens) printed the pointer address of math.Int's *big.Int field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staking-related event data so token amounts are now emitted in a more consistent format.
  * This helps ensure validator removal events display the expected token values in logs and downstream integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->